### PR TITLE
Fix #52: ExcitationPreserving reaches chemical accuracy, reproducible seeds, and data-integrity fixes

### DIFF
--- a/docker/airflow/scripts/quantum_incremental_processing.py
+++ b/docker/airflow/scripts/quantum_incremental_processing.py
@@ -23,7 +23,10 @@ except ModuleNotFoundError:
 
     def create_spark_session(app_name):
         from pyspark.sql import SparkSession
+
         return SparkSession.builder.appName(app_name).getOrCreate()
+
+
 from pyspark.sql.functions import (
     array_join,
     coalesce,
@@ -34,10 +37,11 @@ from pyspark.sql.functions import (
     expr,
     lit,
     posexplode,
+    sha2,
     size,
-    udf,
+    struct,
+    to_json,
 )
-from pyspark.sql.types import StringType
 
 logger = logging.getLogger(__name__)
 
@@ -91,15 +95,18 @@ def read_experiments_by_topic(spark, bucket_path, topic_name, num_partitions=Non
     topic_dir = f'{bucket_path}{topic_name}'
 
     try:
-        df = (spark.read.format('avro')
-              .option('recursiveFileLookup', 'true')
-              .option('pathGlobFilter', '*.avro')
-              .load(topic_dir))
+        df = (
+            spark.read.format('avro')
+            .option('recursiveFileLookup', 'true')
+            .option('pathGlobFilter', '*.avro')
+            .load(topic_dir)
+        )
     except Exception:
-        df = (spark.read
-              .option('recursiveFileLookup', 'true')
-              .option('pathGlobFilter', '*.json')
-              .json(topic_dir))
+        df = (
+            spark.read.option('recursiveFileLookup', 'true')
+            .option('pathGlobFilter', '*.json')
+            .json(topic_dir)
+        )
 
     if num_partitions:
         df = df.repartition(num_partitions)
@@ -119,13 +126,20 @@ def add_metadata_columns(dataframe, processing_name):
     Returns:
         DataFrame: Dataframe with added metadata columns
     """
-    #  udf to generate uuids
-    generate_uuid = udf(lambda: str(uuid.uuid4()), StringType())
+    # deterministic experiment_id.
+    experiment_identity = to_json(
+        struct(
+            col('molecule.molecule_data'),
+            col('basis_set'),
+            col('vqe_result.initial_data'),
+        )
+    )
 
     return (
-        dataframe.withColumn('experiment_id', generate_uuid())
+        dataframe.withColumn('experiment_id', sha2(experiment_identity, 256))
         .withColumn('processing_timestamp', current_timestamp())
         .withColumn('processing_date', current_date())
+        # processing_batch_id marks one job run (not a dedup key) — random is fine here.
         .withColumn('processing_batch_id', lit(str(uuid.uuid4())))
         .withColumn('processing_name', lit(processing_name))
     )
@@ -205,9 +219,7 @@ def process_incremental_data(
         tuple:  version tag and count of new records processed
     """
     # check if table exists
-    table_exists = spark.catalog._jcatalog.tableExists(
-        f'{CATALOG_FQN}.{table_name}'
-    )
+    table_exists = spark.catalog._jcatalog.tableExists(f'{CATALOG_FQN}.{table_name}')
 
     # if the table doesn't exist, create it
     if not table_exists:
@@ -726,7 +738,8 @@ def process_experiments_incrementally(spark, df, topic_name=None):
     processed_count = sum(1 for c in record_counts if c > 0)
     logger.info(
         'Volume check: %d/%d tables received new records this batch',
-        processed_count, len(table_names),
+        processed_count,
+        len(table_names),
     )
 
     summary_parts = [f'{t}={c}' for t, c in zip(table_names, record_counts, strict=True)]
@@ -739,7 +752,8 @@ def process_experiments_incrementally(spark, df, topic_name=None):
             logger.warning(
                 'Volume mismatch: vqe_iterations (%d) < vqe_results (%d) — '
                 'possible truncated Kafka events for this batch',
-                iter_count, results_count,
+                iter_count,
+                results_count,
             )
 
     # release cached dataframes

--- a/quantum_pipeline/cli.py
+++ b/quantum_pipeline/cli.py
@@ -31,7 +31,7 @@ def execute_simulation(**kwargs):
         optimizer=kwargs['optimizer'],
         ansatz_reps=kwargs['ansatz_reps'],
         ansatz_type=kwargs.get('ansatz_type', 'EfficientSU2'),
-        default_shots=kwargs['shots'],
+        default_shots=None if kwargs.get('exact') else kwargs['shots'],
         seed=kwargs.get('seed'),
         init_strategy=kwargs.get('init_strategy', 'random'),
         report=kwargs['report'],

--- a/quantum_pipeline/configs/constants.py
+++ b/quantum_pipeline/configs/constants.py
@@ -10,6 +10,12 @@ HF_FIDELITY_THRESHOLD = 0.9999
 HF_PRE_OPT_ATTEMPTS = 10
 HF_PRE_OPT_MAXITER = 1000
 
+# ExcitationPreserving initial-parameter jitter.
+# Zero params sit exactly on HF, where the gradient vanishes and the optimizer
+# stalls. A small jitter nudges it off HF so it can descend into correlation.
+# 0.1 too timid to escape reliably; 0.5 reaches chemical accuracy across seeds.
+EP_INIT_JITTER = 0.5
+
 # L-BFGS-B optimizer defaults
 LBFGSB_DEFAULT_MAXITER = 15000
 

--- a/quantum_pipeline/configs/parsing/argparser.py
+++ b/quantum_pipeline/configs/parsing/argparser.py
@@ -224,7 +224,16 @@ class QuantumPipelineArgParser:
             '--shots',
             type=self.shots,
             default=DEFAULTS['shots'],
-            help='Number of shots for quantum circuit execution',
+            help='Number of shots for quantum circuit execution (ignored when --exact is set)',
+        )
+        backend_group.add_argument(
+            '--exact',
+            action='store_true',
+            help=(
+                'Use exact statevector expectation values (qiskit_aer EstimatorV2, '
+                'default_precision=0.0) instead of shot sampling. Eliminates shot noise, '
+                'is deterministic, and is faster for noiseless runs. Overrides --shots.'
+            ),
         )
         backend_group.add_argument(
             '--optimization-level',

--- a/quantum_pipeline/configs/parsing/configuration_manager.py
+++ b/quantum_pipeline/configs/parsing/configuration_manager.py
@@ -12,8 +12,16 @@ from quantum_pipeline.configs.module.producer import ProducerConfig
 from quantum_pipeline.monitoring import init_performance_monitoring
 from quantum_pipeline.utils.logger import get_logger
 
-_SENSITIVE_KEYS = {'password', 'token', 'secret', 'pass', 'key', 'ssl_password',
-                    'sasl_plain_password', 'sasl_plain_username'}
+_SENSITIVE_KEYS = {
+    'password',
+    'token',
+    'secret',
+    'pass',
+    'key',
+    'ssl_password',
+    'sasl_plain_password',
+    'sasl_plain_username',
+}
 
 
 def _redact_sensitive(data: Any, _depth: int = 0) -> Any:
@@ -22,7 +30,9 @@ def _redact_sensitive(data: Any, _depth: int = 0) -> Any:
         return data
     if isinstance(data, dict):
         return {
-            k: '***' if any(s in k.lower() for s in _SENSITIVE_KEYS) else _redact_sensitive(v, _depth + 1)
+            k: '***'
+            if any(s in k.lower() for s in _SENSITIVE_KEYS)
+            else _redact_sensitive(v, _depth + 1)
             for k, v in data.items()
         }
     if isinstance(data, list):
@@ -91,6 +101,7 @@ class ConfigurationManager:
                 'gpu': args.gpu,
                 'gpu_opts': DEFAULTS['backend']['gpu_opts'].copy(),
                 'simulation_method': args.simulation_method,
+                'noise': args.noise,
             }
         )
 

--- a/quantum_pipeline/mappers/jordan_winger_mapper.py
+++ b/quantum_pipeline/mappers/jordan_winger_mapper.py
@@ -6,6 +6,7 @@ using the Jordan-Wigner transformation. This transformation is used to represent
 fermionic systems on quantum computers.
 """
 
+from qiskit.quantum_info import SparsePauliOp
 from qiskit_nature.second_q.mappers import JordanWignerMapper as JordanWignerMapperQiskit
 
 from quantum_pipeline.mappers.mapper import Mapper
@@ -31,6 +32,10 @@ class JordanWignerMapper(Mapper):
         """
         if operator is None:
             raise ValueError('The input operator must not be None.')
+
+        # An empty operator has no orbitals to map.
+        if operator.register_length == 0:
+            return SparsePauliOp([''], coeffs=[0j])
 
         # Perform the Jordan-Wigner mapping
         return JordanWignerMapperQiskit().map(operator)

--- a/quantum_pipeline/runners/vqe_runner.py
+++ b/quantum_pipeline/runners/vqe_runner.py
@@ -1,5 +1,7 @@
+import json
 import math
 import os
+from pathlib import Path
 
 import numpy as np
 from qiskit_nature.second_q.drivers.pyscfd.pyscfdriver import PySCFDriver
@@ -15,10 +17,13 @@ from quantum_pipeline.monitoring import get_performance_monitor
 from quantum_pipeline.report.report_generator import ReportGenerator
 from quantum_pipeline.runners.runner import Runner
 from quantum_pipeline.solvers.vqe_solver import VQESolver
-from quantum_pipeline.stream.kafka_interface import VQEKafkaProducer
+from quantum_pipeline.stream.kafka_interface import KafkaProducerError, VQEKafkaProducer
 from quantum_pipeline.structures.vqe_observation import VQEDecoratedResult
 from quantum_pipeline.utils.timer import Timer
 from quantum_pipeline.visual.ansatz import AnsatzViewer
+
+# Local dead-letter directory for results that failed to reach Kafka.
+UNDELIVERED_DIR = Path('gen/undelivered')
 
 
 class VQERunner(Runner):
@@ -139,6 +144,8 @@ class VQERunner(Runner):
                 raise
 
         self.run_results = []
+        # Molecule indices whose results failed to reach Kafka (spooled to disk instead).
+        self._undelivered: list[int] = []
 
         # Initialize performance monitoring
         self.performance_monitor = get_performance_monitor()
@@ -369,14 +376,51 @@ class VQERunner(Runner):
                 self.logger.debug(f'Error closing Kafka producer: {e}')
             self._producer = None
 
-    def _stream_result(self, decorated_result):
-        """Send a decorated VQE result to the Kafka broker."""
+    def _stream_result(self, decorated_result, molecule_id) -> bool:
+        """Send a decorated VQE result to the Kafka broker.
+
+        A failed send must never be silent: the computed result is spooled to disk
+        for replay and the molecule is recorded so run() can exit non-zero. Otherwise
+        a downed broker would drop paid GPU output while the job still reported success.
+
+        Returns True on success, False on failure.
+        """
         try:
             producer = self._get_producer()
             producer.send_result(decorated_result)
+            return True
         except Exception as e:
-            self.logger.error('Unable to send the result to the Kafka broker.')
-            self.logger.debug(f'Error: {e}')
+            self.logger.error(
+                f'Failed to stream result for molecule index {molecule_id} to Kafka: {e}'
+            )
+            self._undelivered.append(molecule_id)
+            self._spool_undelivered(decorated_result, molecule_id)
+            return False
+
+    def _spool_undelivered(self, decorated_result, molecule_id) -> None:
+        """Persist an undelivered result to disk so it can be replayed (no recompute).
+
+        Best-effort: uses the Avro interface's registry-free serialize() to write a
+        JSON record.
+        """
+        producer = getattr(self, '_producer', None)
+        if producer is None:
+            self.logger.error(
+                f'Cannot spool molecule {molecule_id}: producer never initialized. '
+                'Re-run once the broker is reachable (run will exit non-zero).'
+            )
+            return
+        try:
+            UNDELIVERED_DIR.mkdir(parents=True, exist_ok=True)
+            payload = producer.serializer.serialize(decorated_result)
+            path = UNDELIVERED_DIR / f'molecule_{molecule_id}.json'
+            with open(path, 'w') as f:
+                json.dump(payload, f, default=str)
+            self.logger.warning(f'Spooled undelivered result to {path} for later replay.')
+        except Exception as e:
+            self.logger.error(
+                f'Failed to spool undelivered result for molecule {molecule_id}: {e}'
+            )
 
     def run(self):
         self.molecules = self.load_molecules()
@@ -398,7 +442,7 @@ class VQERunner(Runner):
                     self.run_results.append(decorated_result)
 
                     if self.kafka:
-                        self._stream_result(decorated_result)
+                        self._stream_result(decorated_result, molecule_id)
 
                     if self.report:
                         self.logger.info(f'Generating report for molecule {molecule_id + 1}...')
@@ -412,6 +456,15 @@ class VQERunner(Runner):
 
         if self.report:
             self.report_gen.generate_report()
+
+        # Surface streaming failures loudly.
+        # Results spooled (see _spool_undelivered) for replay.
+        if self._undelivered:
+            raise KafkaProducerError(
+                f'{len(self._undelivered)} of {len(self.run_results)} results failed to '
+                f'stream to Kafka (molecule indices {self._undelivered}). They were spooled '
+                f'to {UNDELIVERED_DIR}/ for replay. Failing non-zero so the job is retried.'
+            )
 
     def generate_report(self):
         for result in self.run_results:

--- a/quantum_pipeline/runners/vqe_runner.py
+++ b/quantum_pipeline/runners/vqe_runner.py
@@ -28,12 +28,12 @@ class VQERunner(Runner):
         self,
         filepath,
         basis_set='sto3g',
-        max_iterations=100,
+        max_iterations: int | None = 100,
         convergence_threshold=None,
         optimizer='COBYLA',
         ansatz_reps=3,
         ansatz_type='EfficientSU2',
-        default_shots=1024,
+        default_shots: int | None = 1024,
         seed=None,
         init_strategy='random',
         report=False,
@@ -215,7 +215,10 @@ class VQERunner(Runner):
                 convergence_threshold=self.convergence_threshold,
                 seed=self.seed,
                 init_strategy=self.init_strategy,
-                hf_data=hf_data if self.init_strategy == 'hf' else None,
+                # Always pass HF data:
+                # 'hf' init needs it and ExcitationPreserving requires it structurally.
+                # Other ansatze never read it.
+                hf_data=hf_data,
                 mapper=mapper,
             )
             result = solver.solve()
@@ -263,7 +266,9 @@ class VQERunner(Runner):
             'accuracy_score': min(100, accuracy_score),
         }
 
-    def _build_metrics_data(self, molecule_id, molecule_name, result, total_time, accuracy_metrics) -> dict:
+    def _build_metrics_data(
+        self, molecule_id, molecule_name, result, total_time, accuracy_metrics
+    ) -> dict:
         """Build the metrics dict used for Prometheus export."""
         return {
             'container_type': os.getenv('CONTAINER_TYPE', 'unknown'),
@@ -342,12 +347,8 @@ class VQERunner(Runner):
             mapping_time=np.float64(self.mapping_time),
             vqe_time=np.float64(self.vqe_time),
             total_time=total_time,
-            performance_start=performance_start
-            if self.performance_monitor.is_enabled()
-            else None,
-            performance_end=performance_end
-            if self.performance_monitor.is_enabled()
-            else None,
+            performance_start=performance_start if self.performance_monitor.is_enabled() else None,
+            performance_end=performance_end if self.performance_monitor.is_enabled() else None,
         )
         self.logger.debug('Appended run information to the result.')
 

--- a/quantum_pipeline/solvers/solver.py
+++ b/quantum_pipeline/solvers/solver.py
@@ -14,6 +14,7 @@ class Solver(ABC):
     """Base class for quantum solvers."""
 
     backend_config: BackendConfig
+    seed: int | None = None
 
     def __init__(self):
         self.logger = get_logger(self.__class__.__name__)
@@ -117,6 +118,10 @@ class Solver(ABC):
                     method=self.backend_config.simulation_method,
                     noise_model=noise_model if noise_model else None,
                 )
+
+            if self.seed is not None:
+                backend.set_options(seed_simulator=self.seed)
+                self.logger.info(f'Aer simulator seeded with seed_simulator={self.seed}.')
 
             self.logger.info('Aer simulator backend initialized.')
         else:

--- a/quantum_pipeline/solvers/vqe_solver.py
+++ b/quantum_pipeline/solvers/vqe_solver.py
@@ -91,19 +91,57 @@ class VQESolver(Solver):
         return ansatz_isa, hamiltonian_isa
 
     def _build_ansatz(self, n_qubits):
-        """Build the ansatz circuit based on the configured ansatz_type.
+        """Build the parameterised ansatz circuit for the given number of qubits.
 
-        Supported types: EfficientSU2, RealAmplitudes, ExcitationPreserving.
-        Always builds a plain ansatz (no HF circuit prepended). When using HF
-        init, we compute initial parameters that approximate the HF state
-        through the ansatz instead.
+        Supported ansatz types
+        ----------------------
+        EfficientSU2 / RealAmplitudes
+            General-purpose circuits with no particle-number constraint.
+            Built as a plain circuit without a fixed initial state.
+            When init_strategy='hf', a separate pre-optimization step finds
+            parameters that make the circuit approximate the Hartree-Fock state.
+
+        ExcitationPreserving
+            A circuit built from XX+YY rotation gates. Only moves electrons,
+            so particle-number must be constant.
+
+            Prepending the Heartree-Fock state as the circuit's `initial_state`.
+            This ensures that correct number of electrons resides in correct
+            orbitals before any gate runs - places cirtuit in the right sector
+            from the start.
+
+            Initial parameters are set to zero - no rotations are applied at the start.
+            Circuit outputs exactly the HF reference state - giving a meaningful
+            starting point.
+
+            entanglement='full' is required.
+                Adjacent-only (linear) gates just slide electrons between
+                neighbouring orbitals - a Slater determinant in, a Slater
+                determinant out. The best reachable state is HF, so the
+                correlation energy is unreachable regardless of reps.
+
+                Non-adjacent (full) gates reach over intermediate qubits,
+                which introduces a many-body interaction under Jordan-Wigner.
+                That lets the circuit produce superpositions of configurations
+                and access the correlated states where the correlation energy lives.
+
+            Raises ValueError if hf_data or mapper is not provided.
         """
+        if self.ansatz_type == 'ExcitationPreserving':
+            if self.hf_data is None or self.mapper is None:
+                raise ValueError(
+                    'ExcitationPreserving requires hf_data and mapper. '
+                    'Without an HF initial state the circuit starts in the 0-electron sector '
+                    'and cannot reach the molecular ground state at any reps.'
+                )
+            hf_state = build_hf_initial_state(self.hf_data, self.mapper)
+            return ExcitationPreserving(
+                n_qubits, reps=self.ansatz_reps, entanglement='full', initial_state=hf_state
+            )
+
         ansatze = {
             'EfficientSU2': lambda: EfficientSU2(n_qubits, reps=self.ansatz_reps),
             'RealAmplitudes': lambda: RealAmplitudes(n_qubits, reps=self.ansatz_reps),
-            'ExcitationPreserving': lambda: ExcitationPreserving(
-                n_qubits, reps=self.ansatz_reps, entanglement='linear'
-            ),
         }
         if self.ansatz_type not in ansatze:
             self.logger.warning(
@@ -158,9 +196,17 @@ class VQESolver(Solver):
         """Compute initial ansatz parameters based on the configured strategy."""
         param_num = ansatz.num_parameters
 
+        # ExcitationPreserving prepends the HF circuit as initial_state.
+        # See VQESolver._build_ansatz() for details.
+        if self.ansatz_type == 'ExcitationPreserving':
+            self.logger.info(
+                'ExcitationPreserving: using zero initial parameters (HF state prepended as initial_state)'
+            )
+            return np.zeros(param_num)
+
         if self.init_strategy == 'hf' and self.ansatz_type != 'EfficientSU2':
             self.logger.warning(
-                f'HF init is only supported for EfficientSU2, not {self.ansatz_type}. '
+                f'HF parameter pre-optimization is only supported for EfficientSU2, not {self.ansatz_type}. '
                 'Falling back to random initialization.'
             )
         elif self.init_strategy == 'hf' and self.hf_data is not None and self.mapper is not None:

--- a/quantum_pipeline/solvers/vqe_solver.py
+++ b/quantum_pipeline/solvers/vqe_solver.py
@@ -11,11 +11,13 @@ from qiskit.circuit.library import EfficientSU2, ExcitationPreserving, RealAmpli
 from qiskit.quantum_info import Statevector, state_fidelity
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_aer.backends.aer_simulator import AerBackend
+from qiskit_aer.primitives import EstimatorV2 as AerEstimatorV2
 from qiskit_ibm_runtime import EstimatorV2, Session
 from scipy.optimize import minimize
 
 from quantum_pipeline.circuits import HFData, build_hf_initial_state
 from quantum_pipeline.configs.constants import (
+    EP_INIT_JITTER,
     HF_FIDELITY_THRESHOLD,
     HF_PRE_OPT_ATTEMPTS,
     HF_PRE_OPT_MAXITER,
@@ -47,11 +49,11 @@ class VQESolver(Solver):
         self,
         qubit_op,
         backend_config: BackendConfig,
-        max_iterations=50,
+        max_iterations: int | None = 50,
         optimizer='COBYLA',
         ansatz_reps=3,
         ansatz_type='EfficientSU2',
-        default_shots=1024,
+        default_shots: int | None = 1024,
         convergence_threshold=None,
         optimization_level=3,
         seed=None,
@@ -110,9 +112,11 @@ class VQESolver(Solver):
             orbitals before any gate runs - places cirtuit in the right sector
             from the start.
 
-            Initial parameters are set to zero - no rotations are applied at the start.
-            Circuit outputs exactly the HF reference state - giving a meaningful
-            starting point.
+            Initial parameters are a small jitter around zero (not exactly zero).
+            Zero params output exactly the HF reference, which is a stationary point
+            of the energy (Brillouin's theorem) where the optimizer stalls at HF; a
+            small perturbation breaks that point so it can descend into correlation.
+            See _compute_initial_parameters().
 
             entanglement='full' is required.
                 Adjacent-only (linear) gates just slide electrons between
@@ -196,13 +200,13 @@ class VQESolver(Solver):
         """Compute initial ansatz parameters based on the configured strategy."""
         param_num = ansatz.num_parameters
 
-        # ExcitationPreserving prepends the HF circuit as initial_state.
-        # See VQESolver._build_ansatz() for details.
+        # ExcitationPreserving prepends the HF circuit as initial_state (see _build_ansatz).
         if self.ansatz_type == 'ExcitationPreserving':
+            rng = np.random.default_rng(self.seed if self.seed is not None else 0)
             self.logger.info(
-                'ExcitationPreserving: using zero initial parameters (HF state prepended as initial_state)'
+                'ExcitationPreserving: small jitter around the HF reference for initial parameters'
             )
-            return np.zeros(param_num)
+            return EP_INIT_JITTER * rng.standard_normal(param_num)
 
         if self.init_strategy == 'hf' and self.ansatz_type != 'EfficientSU2':
             self.logger.warning(
@@ -239,6 +243,19 @@ class VQESolver(Solver):
                 f'(nuclear repulsion: {self._nuclear_repulsion:.8f} Ha)'
             )
 
+    def _best_step(self) -> VQEProcess:
+        """Return the VQEProcess with the lowest evaluated energy.
+
+        Keys on the raw per-iteration `result` (not `cumulative_min_energy`), so the
+        returned step's energy and parameters are self-consistent.
+
+        Result is the lowest energy seen and parameters are exactly the ones
+        that produced it. Keying on the running cumulative minimum would pair
+        the global-min energy with whichever iteration's parameters happened
+        to be stored alongside it.
+        """
+        return min(self.vqe_process, key=lambda p: p.result)
+
     def _make_truncated_result(self, best_energy, best_params, elapsed):
         """Build a VQEResult from the best observed state after early termination."""
         return VQEResult(
@@ -256,11 +273,11 @@ class VQESolver(Solver):
         """Return estimate of energy from estimator"""
 
         if self.max_iterations is not None and self.current_iter > self.max_iterations:
-            best = min(self.vqe_process, key=lambda p: p.cumulative_min_energy)
+            best = self._best_step()
             raise MaxFunctionEvalsReachedError(
                 iteration=self.current_iter - 1,
                 best_params=best.parameters,
-                best_energy=float(best.cumulative_min_energy),
+                best_energy=float(best.result),
             )
 
         pub = (ansatz, [hamiltonian], [params])
@@ -271,7 +288,10 @@ class VQESolver(Solver):
             prev = self.vqe_process[-1]
             energy_delta = np.float64(energy - prev.result)
             parameter_delta_norm = np.float64(np.linalg.norm(params - prev.parameters))
-            cumulative_min_energy = np.float64(min(energy, prev.cumulative_min_energy))
+            prev_min = prev.cumulative_min_energy
+            cumulative_min_energy = np.float64(
+                energy if prev_min is None else min(energy, prev_min)
+            )
         else:
             energy_delta = None
             parameter_delta_norm = None
@@ -317,7 +337,9 @@ class VQESolver(Solver):
 
         return x0, ansatz_isa, hamiltonian_isa
 
-    def _build_init_data(self, backend_name, ansatz_isa, hamiltonian_isa, x0):
+    def _build_init_data(
+        self, backend_name, ansatz_isa, hamiltonian_isa, x0, exact_estimator=False
+    ):
         """Construct and store VQEInitialData on self.init_data."""
         self.init_data = VQEInitialData(
             backend=backend_name,
@@ -333,6 +355,7 @@ class VQESolver(Solver):
             seed=self.seed,
             init_strategy=self.init_strategy,
             ansatz_name=self.ansatz_type,
+            exact_estimator=exact_estimator,
         )
 
     def _run_optimization(self, ansatz_isa, hamiltonian_isa, estimator, x0) -> VQEResult:
@@ -393,10 +416,16 @@ class VQESolver(Solver):
                 truncated.best_energy, truncated.best_params, t.elapsed
             )
 
+        # Past the truncated-return above, minimize() completed normally, so res is set.
+        assert res is not None
         actual_iterations = len(self.vqe_process)
-        best_energy = (
-            min(p.cumulative_min_energy for p in self.vqe_process) if self.vqe_process else res.fun
-        )
+        if self.vqe_process:
+            best_step = self._best_step()
+            best_energy = float(best_step.result)
+            best_params = best_step.parameters
+        else:
+            best_energy = res.fun
+            best_params = res.x
         if self.convergence_threshold:
             if res.success:
                 self.logger.info(
@@ -418,8 +447,8 @@ class VQESolver(Solver):
         return VQEResult(
             initial_data=self.init_data,
             iteration_list=self.vqe_process,
-            minimum=res.fun,
-            optimal_parameters=res.x,
+            minimum=np.float64(best_energy),
+            optimal_parameters=best_params,
             maxcv=getattr(res, 'maxcv', None),
             minimization_time=np.float64(t.elapsed),
             nuclear_repulsion_energy=self._nuclear_repulsion,
@@ -446,12 +475,24 @@ class VQESolver(Solver):
         return result
 
     def via_aer(self, backend):
-        """Run the VQE simulation via Aer simulator."""
-        x0, ansatz_isa, hamiltonian_isa = self._prepare_circuit(backend)
-        self._build_init_data(backend.name, ansatz_isa, hamiltonian_isa, x0)
+        """Run the VQE simulation via Aer simulator.
 
-        estimator = EstimatorV2(mode=backend)
-        estimator.options.default_shots = self.default_shots
+        When default_shots is None, uses qiskit_aer.primitives.EstimatorV2 with
+        default_precision=0.0 (exact statevector expectation values, no shot noise).
+        Otherwise uses qiskit_ibm_runtime.EstimatorV2 in local mode with the
+        specified shot count.
+        """
+        x0, ansatz_isa, hamiltonian_isa = self._prepare_circuit(backend)
+
+        exact = self.default_shots is None
+        self._build_init_data(backend.name, ansatz_isa, hamiltonian_isa, x0, exact_estimator=exact)
+
+        if exact:
+            estimator = AerEstimatorV2(options={'default_precision': 0.0})
+            self.logger.info('Using exact Aer estimator (default_precision=0.0, no shot noise).')
+        else:
+            estimator = EstimatorV2(mode=backend)
+            estimator.options.default_shots = self.default_shots
 
         result = self._run_optimization(ansatz_isa, hamiltonian_isa, estimator, x0)
 

--- a/quantum_pipeline/solvers/vqe_solver.py
+++ b/quantum_pipeline/solvers/vqe_solver.py
@@ -36,9 +36,7 @@ class MaxFunctionEvalsReachedError(Exception):
     """Raised when the hard function evaluation limit is exceeded."""
 
     def __init__(self, iteration: int, best_params: np.ndarray, best_energy: float):
-        super().__init__(
-            f'Hard function evaluation limit reached after {iteration} evaluations.'
-        )
+        super().__init__(f'Hard function evaluation limit reached after {iteration} evaluations.')
         self.iteration = iteration
         self.best_params = best_params
         self.best_energy = best_energy
@@ -83,7 +81,9 @@ class VQESolver(Solver):
         """Prepare ISA-compatible circuits and observables"""
         target = backend.target
         pm = generate_preset_pass_manager(
-            target=target, optimization_level=self.optimization_level
+            target=target,
+            optimization_level=self.optimization_level,
+            seed_transpiler=self.seed,
         )
         ansatz_isa = pm.run(ansatz)
 
@@ -132,13 +132,16 @@ class VQESolver(Solver):
         best_fid = 0.0
         best_params = np.zeros(ansatz.num_parameters)
         n_attempts = HF_PRE_OPT_ATTEMPTS
+
         # Default to seed 0 for reproducible HF pre-optimization
         seed = self.seed if self.seed is not None else 0
 
         for i in range(n_attempts):
             rng = np.random.default_rng(seed + i)
             x0 = 2 * np.pi * rng.random(ansatz.num_parameters)
-            res = minimize(neg_fidelity, x0, method='COBYLA', options={'maxiter': HF_PRE_OPT_MAXITER})
+            res = minimize(
+                neg_fidelity, x0, method='COBYLA', options={'maxiter': HF_PRE_OPT_MAXITER}
+            )
             fid = -res.fun
             if fid > best_fid:
                 best_fid = fid
@@ -147,8 +150,7 @@ class VQESolver(Solver):
                 break
 
         self.logger.info(
-            f'HF parameter pre-optimization: fidelity={best_fid:.6f} '
-            f'after {i + 1} attempts'
+            f'HF parameter pre-optimization: fidelity={best_fid:.6f} after {i + 1} attempts'
         )
         return best_params
 
@@ -206,6 +208,7 @@ class VQESolver(Solver):
 
     def compute_energy(self, params, ansatz, hamiltonian, estimator):
         """Return estimate of energy from estimator"""
+
         if self.max_iterations is not None and self.current_iter > self.max_iterations:
             best = min(self.vqe_process, key=lambda p: p.cumulative_min_energy)
             raise MaxFunctionEvalsReachedError(
@@ -340,13 +343,13 @@ class VQESolver(Solver):
                 f'(limit: {self.max_iterations}). Best energy: {truncated.best_energy:.8f} Ha'
             )
             self._log_total_energy(truncated.best_energy)
-            return self._make_truncated_result(truncated.best_energy, truncated.best_params, t.elapsed)
+            return self._make_truncated_result(
+                truncated.best_energy, truncated.best_params, t.elapsed
+            )
 
         actual_iterations = len(self.vqe_process)
         best_energy = (
-            min(p.cumulative_min_energy for p in self.vqe_process)
-            if self.vqe_process
-            else res.fun
+            min(p.cumulative_min_energy for p in self.vqe_process) if self.vqe_process else res.fun
         )
         if self.convergence_threshold:
             if res.success:

--- a/quantum_pipeline/solvers/vqe_solver.py
+++ b/quantum_pipeline/solvers/vqe_solver.py
@@ -417,7 +417,9 @@ class VQESolver(Solver):
             )
 
         # Past the truncated-return above, minimize() completed normally, so res is set.
-        assert res is not None
+        if res is None:
+            raise RuntimeError('Optimization produced no result (minimize did not run).')
+
         actual_iterations = len(self.vqe_process)
         if self.vqe_process:
             best_step = self._best_step()

--- a/quantum_pipeline/stream/serialization/interfaces/vqe.py
+++ b/quantum_pipeline/stream/serialization/interfaces/vqe.py
@@ -166,8 +166,12 @@ class VQEProcessInterface(AvroInterfaceBase[VQEProcess]):
             'result': float(obj.result),
             'std': float(obj.std),
             'energy_delta': float(obj.energy_delta) if obj.energy_delta is not None else None,
-            'parameter_delta_norm': float(obj.parameter_delta_norm) if obj.parameter_delta_norm is not None else None,
-            'cumulative_min_energy': float(obj.cumulative_min_energy) if obj.cumulative_min_energy is not None else None,
+            'parameter_delta_norm': float(obj.parameter_delta_norm)
+            if obj.parameter_delta_norm is not None
+            else None,
+            'cumulative_min_energy': float(obj.cumulative_min_energy)
+            if obj.cumulative_min_energy is not None
+            else None,
         }
 
     def deserialize(self, data: dict[str, Any]) -> VQEProcess:
@@ -176,9 +180,15 @@ class VQEProcessInterface(AvroInterfaceBase[VQEProcess]):
             parameters=self._convert_to_numpy(data['parameters']),
             result=float64(data['result']),
             std=float64(data['std']),
-            energy_delta=float64(data['energy_delta']) if data.get('energy_delta') is not None else None,
-            parameter_delta_norm=float64(data['parameter_delta_norm']) if data.get('parameter_delta_norm') is not None else None,
-            cumulative_min_energy=float64(data['cumulative_min_energy']) if data.get('cumulative_min_energy') is not None else None,
+            energy_delta=float64(data['energy_delta'])
+            if data.get('energy_delta') is not None
+            else None,
+            parameter_delta_norm=float64(data['parameter_delta_norm'])
+            if data.get('parameter_delta_norm') is not None
+            else None,
+            cumulative_min_energy=float64(data['cumulative_min_energy'])
+            if data.get('cumulative_min_energy') is not None
+            else None,
         )
 
 
@@ -222,11 +232,12 @@ class VQEInitialDataInterface(AvroInterfaceBase[VQEInitialData]):
                 {'name': 'optimizer', 'type': 'string'},
                 {'name': 'ansatz', 'type': 'string'},
                 {'name': 'noise_backend', 'type': 'string'},
-                {'name': 'default_shots', 'type': 'int'},
+                {'name': 'default_shots', 'type': ['int', 'null']},
                 {'name': 'ansatz_reps', 'type': 'int'},
                 {'name': 'init_strategy', 'type': ['string', 'null'], 'default': 'random'},
                 {'name': 'seed', 'type': ['null', 'int'], 'default': None},
                 {'name': 'ansatz_name', 'type': ['null', 'string'], 'default': None},
+                {'name': 'exact_estimator', 'type': 'boolean', 'default': False},
             ],
         }
         self._register_schema(self.SCHEMA_NAME, deepcopy(schema))
@@ -277,6 +288,7 @@ class VQEInitialDataInterface(AvroInterfaceBase[VQEInitialData]):
             'init_strategy': obj.init_strategy,
             'seed': int(obj.seed) if obj.seed is not None else None,
             'ansatz_name': obj.ansatz_name,
+            'exact_estimator': obj.exact_estimator,
         }
 
     def deserialize(self, data: dict[str, Any]) -> VQEInitialData:
@@ -294,6 +306,7 @@ class VQEInitialDataInterface(AvroInterfaceBase[VQEInitialData]):
             init_strategy=data.get('init_strategy') or 'random',
             seed=data.get('seed'),
             ansatz_name=data.get('ansatz_name') or 'EfficientSU2',
+            exact_estimator=data.get('exact_estimator', False),
         )
 
 
@@ -337,7 +350,9 @@ class VQEResultInterface(AvroInterfaceBase[VQEResult]):
             'optimal_parameters': self._convert_to_primitives(obj.optimal_parameters),
             'maxcv': float(obj.maxcv) if obj.maxcv is not None else None,
             'minimization_time': float(obj.minimization_time),
-            'nuclear_repulsion_energy': float(obj.nuclear_repulsion_energy) if obj.nuclear_repulsion_energy is not None else None,
+            'nuclear_repulsion_energy': float(obj.nuclear_repulsion_energy)
+            if obj.nuclear_repulsion_energy is not None
+            else None,
             'success': bool(obj.success) if obj.success is not None else None,
             'nfev': int(obj.nfev) if obj.nfev is not None else None,
             'nit': int(obj.nit) if obj.nit is not None else None,
@@ -351,7 +366,9 @@ class VQEResultInterface(AvroInterfaceBase[VQEResult]):
             optimal_parameters=self._convert_to_numpy(data['optimal_parameters']),
             maxcv=float64(data['maxcv']) if data.get('maxcv') is not None else None,
             minimization_time=float64(data['minimization_time']),
-            nuclear_repulsion_energy=float64(data['nuclear_repulsion_energy']) if data.get('nuclear_repulsion_energy') is not None else None,
+            nuclear_repulsion_energy=float64(data['nuclear_repulsion_energy'])
+            if data.get('nuclear_repulsion_energy') is not None
+            else None,
             success=bool(data['success']) if data.get('success') is not None else None,
             nfev=int(data['nfev']) if data.get('nfev') is not None else None,
             nit=int(data['nit']) if data.get('nit') is not None else None,

--- a/quantum_pipeline/structures/vqe_observation.py
+++ b/quantum_pipeline/structures/vqe_observation.py
@@ -18,10 +18,11 @@ class VQEInitialData:
     optimizer: str
     ansatz: QuantumCircuit
     ansatz_reps: int
-    default_shots: int
+    default_shots: int | None
     seed: int | None = None
     init_strategy: str = 'random'
     ansatz_name: str = 'EfficientSU2'
+    exact_estimator: bool = False
 
 
 @dataclass

--- a/scripts/generate_ml_batch.py
+++ b/scripts/generate_ml_batch.py
@@ -225,14 +225,21 @@ def _push_batch_metrics(state_file: Path, tier: int, lanes: dict[str, list]) -> 
 
 def make_run_key(
     lane: str,
+    basis: str,
     optimizer: str,
     init_strategy: str,
     seed: int,
     ansatz: str,
     molecule: str,
 ) -> str:
-    """Unique key per container invocation (lane x molecule x optimizer x init x seed x ansatz)."""
-    return f"{lane}__{molecule}__{optimizer}__{init_strategy}__seed{seed}__{ansatz}"
+    """Unique key per container invocation.
+
+    Must include `basis`: tiers differ by basis set (Tier 1 sto3g, Tier 2 6-31g,
+    Tier 4 cc-pvdz) while sharing molecule/optimizer/init/seed/ansatz. Without basis
+    in the key, those runs collide — once Tier 1 marks a key 'done', the higher-basis
+    tier sees it already complete and is silently skipped while reporting 100%.
+    """
+    return f"{lane}__{basis}__{molecule}__{optimizer}__{init_strategy}__seed{seed}__{ansatz}"
 
 
 # ---------------------------------------------------------------------------
@@ -468,7 +475,9 @@ def generate_run_matrix(
                 for optimizer in optimizers:
                     for init_strategy in config["init_strategies"]:
                         for seed in config["seeds"]:
-                            key = make_run_key(lane, optimizer, init_strategy, seed, ansatz, mol_name)
+                            key = make_run_key(
+                                lane, config["basis"], optimizer, init_strategy, seed, ansatz, mol_name
+                            )
                             lanes[lane].append({
                                 "key": key,
                                 "lane": lane,

--- a/tests/configs/parsing/test_configuration_manager.py
+++ b/tests/configs/parsing/test_configuration_manager.py
@@ -50,6 +50,7 @@ def sample_args():
     args.optimization_level = 1
     args.gpu = False
     args.simulation_method = 'statevector'
+    args.noise = 'ibm_brisbane'
 
     # Other args
     args.file = 'test_file.json'
@@ -88,6 +89,17 @@ def test_create_backend_config(config_manager, sample_args):
     assert backend_config.optimization_level == 1
     assert backend_config.gpu is False
     assert backend_config.simulation_method == 'statevector'
+    # --noise must reach BackendConfig, else runs execute noiseless + mislabeled
+    assert backend_config.noise == 'ibm_brisbane'
+
+
+def test_create_backend_config_propagates_noise(config_manager, sample_args):
+    """Regression: --noise must flow into BackendConfig (was silently dropped)."""
+    sample_args.noise = 'thermal_relaxation'
+    assert config_manager.create_backend_config(sample_args).noise == 'thermal_relaxation'
+
+    sample_args.noise = None  # noiseless run stays noiseless
+    assert config_manager.create_backend_config(sample_args).noise is None
 
 
 @patch('quantum_pipeline.configs.settings')

--- a/tests/runners/test_vqe_runner.py
+++ b/tests/runners/test_vqe_runner.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 from kafka.errors import KafkaError
@@ -724,7 +724,9 @@ class TestVQERunner:
                 convergence_threshold=1e-6,
                 seed=None,
                 init_strategy='random',
-                hf_data=None,
+                # hf_data is now always passed (EP needs it structurally); ANY because
+                # it wraps a Mock nuclear_repulsion_energy that can't be reconstructed here.
+                hf_data=ANY,
                 mapper=mock_mapper.return_value,
             )
 

--- a/tests/runners/test_vqe_runner.py
+++ b/tests/runners/test_vqe_runner.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
@@ -7,6 +8,7 @@ from quantum_pipeline.configs.module.backend import BackendConfig
 from quantum_pipeline.configs.module.producer import ProducerConfig
 from quantum_pipeline.configs.module.security import SecurityConfig
 from quantum_pipeline.runners.vqe_runner import VQERunner
+from quantum_pipeline.stream.kafka_interface import KafkaProducerError
 from quantum_pipeline.structures.vqe_observation import VQEDecoratedResult
 
 
@@ -491,11 +493,14 @@ class TestVQERunner:
             # run the test
             runner = VQERunner(filepath=str(single_molecule_file), basis_set='sto3g', kafka=True)
 
-            # should continue
-            runner.run()
+            # A failed send must NOT pass as success: run() exits non-zero so the job
+            # is retried instead of silently dropping the paid compute output.
+            with pytest.raises(KafkaProducerError):
+                runner.run()
 
-            # check if processing is continued, despite kafka failure
+            # compute is preserved (not lost) and the failure is recorded
             assert len(runner.run_results) == 1
+            assert runner._undelivered == [0]
 
     def test_run_with_report_generation(self, single_molecule_file):
         """Test running with report generation enabled using a real file."""
@@ -745,3 +750,45 @@ class TestVQERunner:
             # see if it was called and if the return value is correct
             mock_default.assert_called_once()
             assert default_backend == mock_backend
+
+
+class TestStreamResultDeadLetter:
+    """Streaming failures must be loud and recoverable, never silently swallowed."""
+
+    @staticmethod
+    def _runner():
+        return VQERunner(filepath='x.json', basis_set='sto3g')
+
+    def test_successful_send_returns_true_no_undelivered(self):
+        runner = self._runner()
+        runner._producer = Mock()  # send_result succeeds (no exception)
+        assert runner._stream_result(Mock(), 0) is True
+        assert runner._undelivered == []
+
+    def test_failed_send_spools_to_disk_and_records(self, tmp_path, monkeypatch):
+        """A transient send failure (producer exists) spools the result for replay."""
+        monkeypatch.setattr(
+            'quantum_pipeline.runners.vqe_runner.UNDELIVERED_DIR', tmp_path / 'undelivered'
+        )
+        runner = self._runner()
+        producer = Mock()
+        producer.send_result.side_effect = KafkaProducerError('broker down')
+        producer.serializer.serialize.return_value = {'molecule_id': 3, 'energy': -1.0}
+        runner._producer = producer
+
+        assert runner._stream_result(Mock(), 3) is False
+        assert runner._undelivered == [3]
+
+        spooled = tmp_path / 'undelivered' / 'molecule_3.json'
+        assert spooled.exists()
+        assert json.loads(spooled.read_text()) == {'molecule_id': 3, 'energy': -1.0}
+
+    def test_failed_send_without_producer_records_but_does_not_crash(self):
+        """Broker down at init (no serializer) still records the failure, no spool, no crash."""
+        runner = self._runner()
+        with patch(
+            'quantum_pipeline.runners.vqe_runner.VQEKafkaProducer',
+            side_effect=KafkaProducerError('no brokers'),
+        ):
+            assert runner._stream_result(Mock(), 0) is False
+        assert runner._undelivered == [0]

--- a/tests/solvers/test_seed_reproducibility.py
+++ b/tests/solvers/test_seed_reproducibility.py
@@ -1,0 +1,63 @@
+"""Regression tests: the same seed must produce bit-identical VQE runs.
+
+Two VQESolver instances with identical configuration and the same seed must
+yield the same energy trajectory and the same final result.
+
+Uses a real AerSimulator on a tiny 2-qubit Hamiltonian (no PySCF needed),
+so the two runs complete in seconds.
+"""
+
+import numpy as np
+import pytest
+from qiskit.quantum_info import SparsePauliOp
+
+from quantum_pipeline.configs.module.backend import BackendConfig
+from quantum_pipeline.solvers.vqe_solver import VQESolver
+
+
+def _statevector_backend_config():
+    """A real (non-mock) local statevector backend configuration."""
+    return BackendConfig(
+        local=True,
+        gpu=False,
+        optimization_level=2,
+        min_num_qubits=None,
+        filters=None,
+        simulation_method='statevector',
+        gpu_opts=None,
+        noise=None,
+    )
+
+
+def _solve(seed):
+    solver = VQESolver(
+        qubit_op=SparsePauliOp.from_list([('ZZ', 1.0), ('XI', 0.5), ('IX', 0.5)]),
+        backend_config=_statevector_backend_config(),
+        max_iterations=15,
+        optimizer='COBYLA',
+        ansatz_reps=1,
+        default_shots=512,
+        seed=seed,
+    )
+    return solver.solve()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('seed', [0, 7])  # 0 is the regression-prone value
+def test_same_seed_runs_are_bit_identical(seed):
+    first = _solve(seed)
+    second = _solve(seed)
+
+    assert float(first.minimum) == float(second.minimum)
+    assert len(first.iteration_list) == len(second.iteration_list)
+    for a, b in zip(first.iteration_list, second.iteration_list, strict=True):
+        assert float(a.result) == float(b.result)
+    np.testing.assert_array_equal(first.optimal_parameters, second.optimal_parameters)
+
+
+@pytest.mark.slow
+def test_different_seeds_differ():
+    """Sanity check: seeding must not collapse distinct seeds onto one trajectory."""
+    energies_a = [float(p.result) for p in _solve(0).iteration_list]
+    energies_b = [float(p.result) for p in _solve(1).iteration_list]
+    assert energies_a != energies_b

--- a/tests/solvers/test_vqe_solver.py
+++ b/tests/solvers/test_vqe_solver.py
@@ -152,7 +152,9 @@ def test_optimize_circuits(vqe_solver):
         )
 
         mock_pm.assert_called_once_with(
-            target=mock_backend.target, optimization_level=vqe_solver.optimization_level
+            target=mock_backend.target,
+            optimization_level=vqe_solver.optimization_level,
+            seed_transpiler=vqe_solver.seed,
         )
         assert optimized_ansatz == mock_ansatz
         mock_hamiltonian.apply_layout.assert_called_once()
@@ -1549,6 +1551,7 @@ class TestOptimizeCircuits:
             mock_pm_gen.assert_called_once_with(
                 target=mock_backend.target,
                 optimization_level=2,
+                seed_transpiler=solver.seed,
             )
 
     def test_returns_isa_pair(self, hamiltonian, backend_config):

--- a/tests/solvers/test_vqe_solver.py
+++ b/tests/solvers/test_vqe_solver.py
@@ -9,7 +9,7 @@ from quantum_pipeline.circuits import HFData
 from quantum_pipeline.configs.module.backend import BackendConfig
 from quantum_pipeline.solvers.optimizer_config import get_optimizer_configuration
 from quantum_pipeline.solvers.vqe_solver import MaxFunctionEvalsReachedError, VQESolver
-from quantum_pipeline.structures.vqe_observation import VQEResult
+from quantum_pipeline.structures.vqe_observation import VQEProcess, VQEResult
 
 
 @pytest.fixture
@@ -103,14 +103,18 @@ def test_compute_energy_derived_features(vqe_solver):
 
     with patch.object(vqe_solver.logger, 'debug'):
         # Iteration 1: first iteration — deltas are None
-        vqe_solver.compute_energy(params1, mock_ansatz, mock_hamiltonian, make_estimator(-1.0, 0.1))
+        vqe_solver.compute_energy(
+            params1, mock_ansatz, mock_hamiltonian, make_estimator(-1.0, 0.1)
+        )
         p1 = vqe_solver.vqe_process[0]
         assert p1.energy_delta is None
         assert p1.parameter_delta_norm is None
         assert p1.cumulative_min_energy == np.float64(-1.0)
 
         # Iteration 2: energy improves
-        vqe_solver.compute_energy(params2, mock_ansatz, mock_hamiltonian, make_estimator(-1.5, 0.05))
+        vqe_solver.compute_energy(
+            params2, mock_ansatz, mock_hamiltonian, make_estimator(-1.5, 0.05)
+        )
         p2 = vqe_solver.vqe_process[1]
         assert p2.energy_delta == pytest.approx(-0.5)
         expected_norm = np.linalg.norm(params2 - params1)
@@ -118,7 +122,9 @@ def test_compute_energy_derived_features(vqe_solver):
         assert p2.cumulative_min_energy == np.float64(-1.5)
 
         # Iteration 3: energy worsens — cumulative_min stays at -1.5
-        vqe_solver.compute_energy(params3, mock_ansatz, mock_hamiltonian, make_estimator(-0.8, 0.2))
+        vqe_solver.compute_energy(
+            params3, mock_ansatz, mock_hamiltonian, make_estimator(-0.8, 0.2)
+        )
         p3 = vqe_solver.vqe_process[2]
         assert p3.energy_delta == pytest.approx(0.7)
         expected_norm3 = np.linalg.norm(params3 - params2)
@@ -545,19 +551,20 @@ class TestMaxFunctionEvalsReachedError:
         vqe_solver.max_iterations = 3
         vqe_solver.current_iter = 4  # one past the limit
 
-        # Populate vqe_process with mock data so min() works
+        # Populate vqe_process with mock data so min() works.
+        # _best_step keys on `result` (raw energy), reporting that step's params/energy.
         mock_process = MagicMock()
+        mock_process.result = -1.5
         mock_process.cumulative_min_energy = -1.5
         mock_process.parameters = np.array([0.1, 0.2])
         vqe_solver.vqe_process = [mock_process]
 
         with pytest.raises(MaxFunctionEvalsReachedError) as exc_info:
-            vqe_solver.compute_energy(
-                np.array([0.1, 0.2]), MagicMock(), MagicMock(), MagicMock()
-            )
+            vqe_solver.compute_energy(np.array([0.1, 0.2]), MagicMock(), MagicMock(), MagicMock())
 
         assert exc_info.value.iteration == 3
         assert exc_info.value.best_energy == -1.5
+        np.testing.assert_array_equal(exc_info.value.best_params, np.array([0.1, 0.2]))
 
     def test_compute_energy_runs_within_limit(self, vqe_solver):
         """Test that compute_energy runs normally when within the limit."""
@@ -790,7 +797,9 @@ class TestVQESolverHFInit:
         mock_minimize_result.success = True
 
         # For HF init, mock the pre-optimization to avoid needing real quantum circuits
-        hf_init_params = np.ones(16) * 0.5 if init_strategy == 'hf' and hf_data is not None else None
+        hf_init_params = (
+            np.ones(16) * 0.5 if init_strategy == 'hf' and hf_data is not None else None
+        )
 
         with (
             patch.object(
@@ -992,24 +1001,33 @@ class TestAnsatzTypes:
         mock_ansatz = MagicMock()
         mock_ansatz.num_parameters = 12
         params = solver._compute_initial_parameters(mock_ansatz)
-        assert np.all(params == 0.0)
         assert len(params) == 12
+        # Jitter around zero (not exactly zero): escapes the HF stationary point while
+        # staying near the HF reference — spread well under a full random [0, 2π] init.
+        assert not np.all(params == 0.0)
+        assert np.std(params) < 1.5
+        assert np.all(np.abs(params) < 2 * np.pi)
 
-    def test_excitation_preserving_initial_params_always_zero(
+    def test_excitation_preserving_initial_params_seeded_deterministic(
         self, mock_backend_config, sample_hamiltonian
     ):
-        """ExcitationPreserving always returns zero initial params — HF state is in the circuit."""
-        solver = VQESolver(
-            qubit_op=sample_hamiltonian,
-            backend_config=mock_backend_config,
-            ansatz_type='ExcitationPreserving',
-            seed=42,
-        )
+        """ExcitationPreserving jitter is seeded → identical across solver instances."""
         mock_ansatz = MagicMock()
         mock_ansatz.num_parameters = 12
-        params = solver._compute_initial_parameters(mock_ansatz)
-        assert len(params) == 12
-        assert np.all(params == 0.0)
+
+        def make(seed):
+            s = VQESolver(
+                qubit_op=sample_hamiltonian,
+                backend_config=mock_backend_config,
+                ansatz_type='ExcitationPreserving',
+                seed=seed,
+            )
+            return s._compute_initial_parameters(mock_ansatz)
+
+        np.testing.assert_array_equal(make(42), make(42))
+        assert not np.array_equal(make(0), make(1))
+        # None seed falls back to a fixed default seed → still deterministic.
+        np.testing.assert_array_equal(make(None), make(None))
 
     def test_unknown_ansatz_type_falls_back_to_efficient_su2(
         self, mock_backend_config, sample_hamiltonian
@@ -1590,6 +1608,143 @@ class TestSolve:
         mock_ibmq.assert_called_once_with(mock_backend)
         mock_aer.assert_not_called()
         assert result == mock_result
+
+
+class TestExactEstimatorAndBestStep:
+    """Fix B: exact Aer estimator when default_shots=None; best-step result consistency."""
+
+    @staticmethod
+    def _mock_via_aer_result():
+        """Minimal mock result compatible with via_aer's post-optimization logging."""
+        r = MagicMock()
+        r.minimization_time = 0.1
+        r.iteration_list = []
+        return r
+
+    def test_via_aer_uses_aer_estimator_when_shots_none(self, hamiltonian, backend_config):
+        """default_shots=None → AerEstimatorV2 with default_precision=0.0."""
+        solver = _make_solver(hamiltonian, backend_config, default_shots=None)
+        mock_backend = MagicMock(spec=AerBackend)
+        mock_backend.name = 'aer_simulator'
+
+        with (
+            patch.object(
+                solver, '_prepare_circuit', return_value=(np.zeros(2), MagicMock(), MagicMock())
+            ),
+            patch.object(solver, '_build_init_data'),
+            patch.object(solver, '_run_optimization', return_value=self._mock_via_aer_result()),
+            patch('quantum_pipeline.solvers.vqe_solver.AerEstimatorV2') as mock_aer_est,
+            patch('quantum_pipeline.solvers.vqe_solver.EstimatorV2') as mock_rt_est,
+        ):
+            solver.via_aer(mock_backend)
+            mock_aer_est.assert_called_once_with(options={'default_precision': 0.0})
+            mock_rt_est.assert_not_called()
+
+    def test_via_aer_uses_runtime_estimator_when_shots_set(self, hamiltonian, backend_config):
+        """default_shots=64 → RuntimeEstimatorV2 in local mode."""
+        solver = _make_solver(hamiltonian, backend_config, default_shots=64)
+        mock_backend = MagicMock(spec=AerBackend)
+        mock_backend.name = 'aer_simulator'
+
+        with (
+            patch.object(
+                solver, '_prepare_circuit', return_value=(np.zeros(2), MagicMock(), MagicMock())
+            ),
+            patch.object(solver, '_build_init_data'),
+            patch.object(solver, '_run_optimization', return_value=self._mock_via_aer_result()),
+            patch('quantum_pipeline.solvers.vqe_solver.AerEstimatorV2') as mock_aer_est,
+            patch('quantum_pipeline.solvers.vqe_solver.EstimatorV2') as mock_rt_est,
+        ):
+            solver.via_aer(mock_backend)
+            mock_rt_est.assert_called_once_with(mode=mock_backend)
+            mock_aer_est.assert_not_called()
+
+    def test_exact_estimator_flag_in_init_data(self, hamiltonian, backend_config):
+        """exact_estimator=True recorded in VQEInitialData when default_shots=None."""
+        solver = _make_solver(hamiltonian, backend_config, default_shots=None)
+        mock_backend = MagicMock(spec=AerBackend)
+        mock_backend.name = 'aer_simulator'
+
+        with (
+            patch.object(
+                solver, '_prepare_circuit', return_value=(np.zeros(2), MagicMock(), MagicMock())
+            ),
+            patch.object(solver, '_run_optimization', return_value=self._mock_via_aer_result()),
+            patch('quantum_pipeline.solvers.vqe_solver.AerEstimatorV2'),
+        ):
+            solver.via_aer(mock_backend)
+            assert solver.init_data.exact_estimator is True
+
+    def test_exact_estimator_false_when_shots_set(self, hamiltonian, backend_config):
+        """exact_estimator=False recorded in VQEInitialData when shots are set."""
+        solver = _make_solver(hamiltonian, backend_config, default_shots=64)
+        mock_backend = MagicMock(spec=AerBackend)
+        mock_backend.name = 'aer_simulator'
+
+        with (
+            patch.object(
+                solver, '_prepare_circuit', return_value=(np.zeros(2), MagicMock(), MagicMock())
+            ),
+            patch.object(solver, '_run_optimization', return_value=self._mock_via_aer_result()),
+            patch('quantum_pipeline.solvers.vqe_solver.EstimatorV2'),
+        ):
+            solver.via_aer(mock_backend)
+            assert solver.init_data.exact_estimator is False
+
+    def test_run_optimization_reports_best_step_not_final_iterate(
+        self, hamiltonian, backend_config
+    ):
+        """minimum and optimal_parameters come from the best VQEProcess, not the final iterate.
+
+        Proves the fix for the biased-minimum bug: the optimizer's final point
+        (res.fun, res.x) may not be the lowest energy seen. The result must report
+        the iteration that achieved the global minimum so energy and parameters
+        are self-consistent.
+        """
+        solver = _make_solver(hamiltonian, backend_config)
+
+        best_params = np.array([0.5, 0.6])
+        solver.vqe_process = [
+            VQEProcess(
+                iteration=1,
+                parameters=np.array([0.1, 0.2]),
+                result=np.float64(-0.8),
+                std=np.float64(0.0),
+                cumulative_min_energy=np.float64(-0.8),
+            ),
+            VQEProcess(
+                iteration=2,
+                parameters=best_params,
+                result=np.float64(-1.5),
+                std=np.float64(0.0),
+                cumulative_min_energy=np.float64(-1.5),  # global min at iteration 2
+            ),
+            VQEProcess(
+                iteration=3,
+                parameters=np.array([0.9, 1.0]),
+                result=np.float64(-1.1),
+                std=np.float64(0.0),
+                cumulative_min_energy=np.float64(-1.5),  # still -1.5 (iter 2 was best)
+            ),
+        ]
+        solver.init_data = MagicMock()
+
+        mock_res = _mock_minimize_result(fun=-1.1)  # final iterate energy ≠ best
+        mock_res.x = np.array([0.9, 1.0])
+        mock_res.nfev = 3
+        mock_res.nit = 3
+
+        with (
+            patch(
+                'quantum_pipeline.solvers.vqe_solver.get_optimizer_configuration',
+                return_value=({'maxiter': 3}, None),
+            ),
+            patch('quantum_pipeline.solvers.vqe_solver.minimize', return_value=mock_res),
+        ):
+            result = solver._run_optimization(MagicMock(), MagicMock(), MagicMock(), np.zeros(2))
+
+        assert result.minimum == pytest.approx(-1.5)
+        assert np.array_equal(result.optimal_parameters, best_params)
 
 
 class TestOptimizeCircuits:

--- a/tests/solvers/test_vqe_solver.py
+++ b/tests/solvers/test_vqe_solver.py
@@ -936,17 +936,80 @@ class TestAnsatzTypes:
             solver._build_ansatz(4)
             mock_cls.assert_called_once_with(4, reps=2)
 
-    def test_build_ansatz_excitation_preserving(self, mock_backend_config, sample_hamiltonian):
-        """Test that _build_ansatz builds ExcitationPreserving with linear entanglement."""
+    def test_build_ansatz_excitation_preserving_raises_without_hf_data(
+        self, mock_backend_config, sample_hamiltonian
+    ):
+        """ExcitationPreserving without HF data must raise — silent vacuum trap is worse than a crash."""
         solver = VQESolver(
             qubit_op=sample_hamiltonian,
             backend_config=mock_backend_config,
             ansatz_type='ExcitationPreserving',
             ansatz_reps=2,
         )
-        with patch('quantum_pipeline.solvers.vqe_solver.ExcitationPreserving') as mock_cls:
+        with pytest.raises(ValueError, match='hf_data and mapper'):
             solver._build_ansatz(4)
-            mock_cls.assert_called_once_with(4, reps=2, entanglement='linear')
+
+    def test_build_ansatz_excitation_preserving_with_hf_data(
+        self, mock_backend_config, sample_hamiltonian
+    ):
+        """Test ExcitationPreserving with HF data passes the HF circuit as initial_state."""
+        hf_data = HFData(num_particles=(1, 1), num_spatial_orbitals=2)
+        mock_mapper = MagicMock()
+        solver = VQESolver(
+            qubit_op=sample_hamiltonian,
+            backend_config=mock_backend_config,
+            ansatz_type='ExcitationPreserving',
+            ansatz_reps=2,
+            hf_data=hf_data,
+            mapper=mock_mapper,
+        )
+        mock_hf_circuit = MagicMock()
+        with (
+            patch('quantum_pipeline.solvers.vqe_solver.ExcitationPreserving') as mock_cls,
+            patch(
+                'quantum_pipeline.solvers.vqe_solver.build_hf_initial_state',
+                return_value=mock_hf_circuit,
+            ),
+        ):
+            solver._build_ansatz(4)
+            mock_cls.assert_called_once_with(
+                4, reps=2, entanglement='full', initial_state=mock_hf_circuit
+            )
+
+    def test_excitation_preserving_initial_params_zero_with_hf_data(
+        self, mock_backend_config, sample_hamiltonian
+    ):
+        """ExcitationPreserving + HF data → zero initial parameters (θ=0 is the HF state)."""
+        hf_data = HFData(num_particles=(1, 1), num_spatial_orbitals=2)
+        mock_mapper = MagicMock()
+        solver = VQESolver(
+            qubit_op=sample_hamiltonian,
+            backend_config=mock_backend_config,
+            ansatz_type='ExcitationPreserving',
+            hf_data=hf_data,
+            mapper=mock_mapper,
+        )
+        mock_ansatz = MagicMock()
+        mock_ansatz.num_parameters = 12
+        params = solver._compute_initial_parameters(mock_ansatz)
+        assert np.all(params == 0.0)
+        assert len(params) == 12
+
+    def test_excitation_preserving_initial_params_always_zero(
+        self, mock_backend_config, sample_hamiltonian
+    ):
+        """ExcitationPreserving always returns zero initial params — HF state is in the circuit."""
+        solver = VQESolver(
+            qubit_op=sample_hamiltonian,
+            backend_config=mock_backend_config,
+            ansatz_type='ExcitationPreserving',
+            seed=42,
+        )
+        mock_ansatz = MagicMock()
+        mock_ansatz.num_parameters = 12
+        params = solver._compute_initial_parameters(mock_ansatz)
+        assert len(params) == 12
+        assert np.all(params == 0.0)
 
     def test_unknown_ansatz_type_falls_back_to_efficient_su2(
         self, mock_backend_config, sample_hamiltonian

--- a/tests/stream/serialization/interfaces/test_serialization_interfaces.py
+++ b/tests/stream/serialization/interfaces/test_serialization_interfaces.py
@@ -309,10 +309,11 @@ class TestVQEInitialDataInterface(unittest.TestCase):
 
         self.assertIsInstance(schema, dict)
         self.assertEqual(schema['name'], 'VQEInitialData')
-        self.assertEqual(len(schema['fields']), 13)
+        self.assertEqual(len(schema['fields']), 14)
         field_names = [f['name'] for f in schema['fields']]
         self.assertIn('seed', field_names)
         self.assertIn('ansatz_name', field_names)
+        self.assertIn('exact_estimator', field_names)
 
     def test_serialize_hamiltonian(self):
         """Test serialization of Hamiltonian terms."""
@@ -1020,6 +1021,7 @@ class TestVQEDecoratedResultInterface(unittest.TestCase):
                     'noise_backend': 'fake_noise_backend',
                     'default_shots': 1024,
                     'ansatz_reps': 1,
+                    'exact_estimator': False,
                 },
                 'iteration_list': [
                     {'iteration': 0, 'parameters': [0.1, 0.2, 0.3], 'result': -74.0, 'std': 0.02},
@@ -1081,6 +1083,7 @@ class TestVQEDecoratedResultInterface(unittest.TestCase):
                     'noise_backend': 'fake_noise_backend',
                     'default_shots': 1024,
                     'ansatz_reps': 1,
+                    'exact_estimator': False,
                 },
                 'iteration_list': [
                     {'iteration': 0, 'parameters': [0.1, 0.2, 0.3], 'result': -74.0, 'std': 0.02},

--- a/tests/stream/test_spark_extraction.py
+++ b/tests/stream/test_spark_extraction.py
@@ -398,3 +398,61 @@ class TestVQEIterationsDeduplication:
         """Should have exactly 2 distinct iterations for the test record."""
         count = transformed['vqe_iterations'].count()
         assert count == 2
+
+
+class TestDeterministicExperimentId:
+    """experiment_id must be a deterministic hash of the experiment identity.
+
+    Regression for the CRITICAL uuid4 bug: a random per-row experiment_id defeats
+    the dedup in identify_new_records (the same record gets a fresh id every run),
+    so each daily run re-appends the whole dataset. The id must be stable across
+    re-processing of the same record, and distinct across genuinely different runs.
+    """
+
+    def test_experiment_id_is_deterministic_across_runs(self, sample_df):
+        """Re-processing the same record yields the same experiment_id (dedup can match)."""
+        first = transform_quantum_data(sample_df)['vqe_results'].select('experiment_id').first()
+        second = transform_quantum_data(sample_df)['vqe_results'].select('experiment_id').first()
+        assert first['experiment_id'] == second['experiment_id']
+
+    def test_experiment_id_is_sha256_not_uuid(self, transformed):
+        """The id is a 64-char hex sha256 digest, not a random uuid4 (36 chars, dashed)."""
+        exp_id = transformed['vqe_results'].select('experiment_id').first()['experiment_id']
+        assert len(exp_id) == 64
+        assert '-' not in exp_id
+        assert all(c in '0123456789abcdef' for c in exp_id)
+
+    def test_distinct_seed_yields_distinct_experiment_id(self, sample_df):
+        """A different seed is a different experiment → different id (no false dedup)."""
+        from pyspark.sql.functions import col, lit
+
+        base_id = transform_quantum_data(sample_df)['vqe_results'].select('experiment_id').first()[
+            'experiment_id'
+        ]
+        df_other_seed = sample_df.withColumn(
+            'vqe_result', col('vqe_result').withField('initial_data.seed', lit(99))
+        )
+        other_id = transform_quantum_data(df_other_seed)['vqe_results'].select(
+            'experiment_id'
+        ).first()['experiment_id']
+        assert base_id != other_id
+
+    def test_distinct_basis_yields_distinct_experiment_id(self, sample_df):
+        """A different basis set is a different experiment → different id."""
+        from pyspark.sql.functions import lit
+
+        base_id = transform_quantum_data(sample_df)['vqe_results'].select('experiment_id').first()[
+            'experiment_id'
+        ]
+        df_other_basis = sample_df.withColumn('basis_set', lit('cc-pvdz'))
+        other_id = transform_quantum_data(df_other_basis)['vqe_results'].select(
+            'experiment_id'
+        ).first()['experiment_id']
+        assert base_id != other_id
+
+    def test_child_tables_share_the_same_experiment_id(self, transformed):
+        """The deterministic id propagates unchanged to every child table."""
+        vqe_id = transformed['vqe_results'].select('experiment_id').first()['experiment_id']
+        for table in ('molecules', 'ansatz_info', 'performance_metrics', 'vqe_iterations'):
+            row = transformed[table].select('experiment_id').first()
+            assert row['experiment_id'] == vqe_id, f'{table} experiment_id diverged'


### PR DESCRIPTION
Closes #52.

Resolves the two reported findings and sweeps some data integrity bugs.

## Issue #52

1. **ExcitationPreserving never reached the ground state.** Caused by three problems were stacked on top of each other:
    1. **Wrong sector.** Zero electrons, and a particle-conserving ansatz can never add
      any, so the molecular ground state is unreachable.
    2. **Matchgate cap.** Even with the Hartree-Fock state prepended, the shipped
      `iswap`+`linear` config is a free-fermion circuit - electrons only move and don't
      interract. So it caps at exactly E_HF.
    3. **Stationary start.** Zero initial parameters land exactly on the HF state.
      A stationary point the optimizer can't descend from.

    Fixed all three: HF `initial_state`, `entanglement='full'`, and a small jitter off
    zero. EP now reaches chemical accuracy and improves with reps.

2. **Same seed, different results.** The seed never reached the simulator. It now seeds
    the Aer backend (`seed_simulator`) and the transpiler. Also added an exact statevector
    path (`--exact` / `default_shots=None`) with no shot noise.

3. **Biased minimum.** The reported energy was the luckiest noisy sample. It now reports
    the best evaluated step (energy and parameters from the same iteration), and the exact
    path removes the bias at the source.

## Data-integrity fixes

1. **spark:** `experiment_id` was a per-row `uuid4()` - it defeated dedup and
    duplicated the whole dataset every day. Fixed with a `sha2` of the experiment
    identity.
2. **config:** `--noise` was dropped in `create_backend_config`, so noisy runs executed
    noiseless and were mislabeled.
3. **batch:** the run key omitted `basis_set`, so higher-basis tiers were silently
    skipped while reporting 100%.
4. **runner:** `KafkaProducerError` was swallowed with exit 0. Now the result is spooled
    to `gen/undelivered/` and the run exits non-zero so it gets retried.

## Notes

- Behavior changes: EP raises without `hf_data`; `run()` exits non-zero on a Kafka send failure;
  `minimum` is now the best step.
- Avro schema stays backward/forward compatible (defaulted fields).
- Targets a **2.1.0** release. The pre-fix ExcitationPreserving data is meaningless and should
  be regenerated.